### PR TITLE
Fix start-stop analyzing flow

### DIFF
--- a/lib/stopAnalyzing.js
+++ b/lib/stopAnalyzing.js
@@ -3,6 +3,8 @@
  */
 export default async function (clearStats = false) {
     this.connection = undefined
+    this.analyzingScriptIsInjected = false
+
     return await this.browser.execute((clearStats) => {
         if (clearStats) {
             window._webdriverrtc = undefined


### PR DESCRIPTION
Hi! I've faced, that It is currently impossible to execute startAnalyzing() -> stopAnalyaing() -> startAnalyzing() cause of analyzingScriptIsInjected var. I propose a simple fix for this.